### PR TITLE
fix: only apply to modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,6 @@
 const { existsSync } = require('fs')
 const { dirname, resolve } = require('path')
 
-const extensions = ['js', 'ts', 'jsx', 'tsx']
-
 module.exports = {
     configs: {
         recommended: {

--- a/index.js
+++ b/index.js
@@ -3,10 +3,6 @@ const { dirname, resolve } = require('path')
 
 const extensions = ['js', 'ts', 'jsx', 'tsx']
 
-function moduleExists(path) {
-    return ext => existsSync(`${path}.${ext}`)
-}
-
 module.exports = {
     configs: {
         recommended: {
@@ -28,7 +24,7 @@ module.exports = {
                     const value = source.value;
                     if (!value || !value.startsWith('.') || value.endsWith('.js')) return;
 
-                    if (extensions.some(moduleExists(resolve(dirname(context.getFilename()), value)))) {
+                    if (!existsSync(resolve(dirname(context.getFilename()), value))) {
                         context.report({
                             node,
                             message: 'Relative imports and exports must end with .js',

--- a/index.js
+++ b/index.js
@@ -1,3 +1,12 @@
+const { existsSync } = require('fs')
+const { dirname, resolve } = require('path')
+
+const extensions = ['js', 'ts', 'jsx', 'tsx']
+
+function moduleExists(path) {
+    return ext => existsSync(`${path}.${ext}`)
+}
+
 module.exports = {
     configs: {
         recommended: {
@@ -17,9 +26,9 @@ module.exports = {
                     const source = node.source;
                     if (!source) return;
                     const value = source.value;
-                    if (!value) return;
+                    if (!value || !value.startsWith('.') || value.endsWith('.js')) return;
 
-                    if (value.startsWith('.') && !value.endsWith('.js')) {
+                    if (extensions.some(moduleExists(resolve(dirname(context.getFilename()), value)))) {
                         context.report({
                             node,
                             message: 'Relative imports and exports must end with .js',


### PR DESCRIPTION
This is an attempt to fix #1 

I would like to add some tests but this is my first time writing code for an eslint plugins and not sure how to proceed

About the change itself, it find the actual module in the filesystem and applies to rule only when a module exists with one of the extensions

For example, given code like

```js
import foo from './bar.json'
```

An error will be shown when there is a source file `bar.json.js` or `bar.json.ts` but not when it's simply `bar.json`

I'm not sure if it's correct to also include `jsx` and `tsx` in the extensions to check.